### PR TITLE
Add ivoatex submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ivoatex"]
+	path = ivoatex
+	url = https://github.com/ivoa-std/ivoatex.git

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1,9 +1,6 @@
 \documentclass[11pt,a4paper]{ivoa}
 \input tthdefs
 
-\SVN$Rev$
-\SVN$Date$
-\SVN$URL$
 
 \usepackage[utf8]{inputenc}
 \usepackage{tabularx}


### PR DESCRIPTION
This includes ivoatex as a submodule. This also requires that the SVN tag templates are removed.

The PR was created with
```
$ git submodule add https://github.com/ivoa-std/ivoatex.git ivoatex
$ git commit -m "Add ivoatex submodule"
$ sed -i '/^\\SVN\$/d' -i ADQL.tex 
$ git commit -m "Remove unused SVN tags" ADQL.tex
```

Checking out and cloning should be done with adding the  `--recurse-submodules` option.