### PR TITLE
Add travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: c
+
+os:
+  - linux
+
+addons:
+  apt:
+    packages:
+      - texlive-latex-base
+      - texlive-latex-recommended
+      - texlive-latex-extra
+      - texlive-fonts-recommended
+      - latex-xcolor
+      - xsltproc
+
+before_install:
+  - make biblio forcetex html
+
+script:
+  - test -f ADQL.pdf
+  - test -f ADQL.html
+  - test -f ADQL.bbl


### PR DESCRIPTION
The goal here is to check for simple build errors on commits or pull requests. This also *could* be used to automatically deploy the PDF and the HTML for tagged versions.

To bring it to work, this requires the ivoatex submodule in place (#1).

To actually use it in the ivoa-std repository, [Travis CI](https://travis-ci.com) needs to be set up [here](https://github.com/organizations/ivoa-std/settings/installations) (I can't do it since I don't have the permissions).