### PR TITLE
Fix `IN_UNIT` example with unit inference.

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -2874,8 +2874,6 @@ Examples, with an \emph{advanced} unit inference mechanism:
     IN_UNIT(ra+10, 'rad')                                   -- OK
 
     IN_UNIT(sqrt(power(pm_ra,2)+power(pm_dec,2)), 'rad/yr') -- OK
-
-    IN_UNIT(ra + IN_UNIT(10, 'deg'), 'rad')                 -- OK
 \end{verbatim}
 
 Note that the complexity and the behavior of a unit inference mechanism is


### PR DESCRIPTION
`IN_UNIT(10, 'deg')` is unitless and raises and error ; so
`IN_UNIT(ra + IN_UNIT(10, 'deg'), 'rad')` can not be 'OK'.
This example has no sense.

_Problem raised by @Zarquan in PR #27_