### PR TITLE
Fix the GitHub CI building the PDF Preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -35,10 +35,10 @@ jobs:
         test -f ${{ env.doc_name }}.bbl
     
     - name: Move the auto-pdf-preview tag
-      uses: weareyipyip/walking-tag-action@v1
+      uses: weareyipyip/walking-tag-action@v2
       with:
-        TAG_NAME: auto-pdf-preview
-        TAG_MESSAGE: |
+        tag-name: auto-pdf-preview
+        tag-message: |
           Last commit taken into account for the automatically updated PDF preview of this IVOA document.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the tag name and message for the GitHub Action [Walking Tag](https://github.com/marketplace/actions/walking-git-tag) accordingly to the last version. This make disappear the warning message about the former `TAG_NAME` and `TAG_MESSAGE`.

_See the Walking-Tag's [commit 5242039](https://github.com/weareyipyip/walking-tag-action/commit/52420390b4d4f7d32fd02d9c57432d8ebacacc22) for more details about this change._

Unfortunately, this PullRequest has to be accepted in order to check whether this update works. It should be ok though.

The only change I have to doubt about is the version number `@v1` into `@v2`. The doc of the GitHub Action still says `@v1`, but the actual version is `@v2`. So let's see...if it does not work, we will move back to `@v1` (with another PullRequest).

When this Pull Request + Commit works, this update will be added to [ivoatex](https://github.com/ivoa-std/ivoatex/tree/master).