### PR TITLE
Fix typos and Update PR version/date

### DIFF
--- a/ADQL.bib
+++ b/ADQL.bib
@@ -1,0 +1,9 @@
+@misc{note:VOARCH,
+	year=2010,
+	month=nov,
+	addurl={http://www.ivoa.net/documents/Notes/IVOAArchitecture},
+	author={Christophe Arviset and Severin Gaudet and the {IVOA} Technical Coordination Group},
+	editor = {Christophe Arviset},
+	title = {{IVOA} Architecture},
+	version = {1.0},
+	howpublished = {{IVOA Note}}}

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -4197,7 +4197,7 @@ issues that are still to be resolved.
 
 \end{itemize}
 
-\bibliography{ivoatex/ivoabib,ivoatex/docrepo}
+\bibliography{ivoatex/ivoabib,ivoatex/docrepo,ADQL}
 
 \end{document}
 

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -3993,35 +3993,6 @@ For example, the following XML fragment describes a service that supports the
 \end{verbatim}
 
 \newpage
-\section{Outstanding issues}
-\label{sec:issues}
-
-The following section identifies areas of the specification that have known
-issues that are still to be resolved.
-
-\begin{itemize}
-
-    \item 20171129-003 Now that we allow polymorphism, do we still need to deprecate
-    the coordsys param for BOX, CIRCLE AND POLYGON? \SectionSee{sec:geom.coordsys.param}.
-
-    \item 20171129-004 Should support for REGION be optional (if so, how) ? \SectionSee{sec:types.geom.region}
-    \item 20171129-005 Should we add a literal constructor for REGION? \SectionSee{sec:types.geom.region}.
-
-    \item 20171129-007 Should we add prefixes to the xytpe names to indicate
-    which standard they are defined in?.
-
-    \item 20171129-008 INTERVAL is defined in DALI but not in ADQL. \SectionSee{sec:types.numeric.interval}.
-
-    \item 20170608-009 Can we add in ADQL an INTERSECTION function
-    which returns the polygon intersection of two regions?.
-    http://mail.ivoa.net/pipermail/dal/2017-June/007721.html
-
-    \item 20171228-010 Table inserted between text and example (POINT).
-
-
-\end{itemize}
-
-\newpage
 \section{Changes from previous versions}
 \label{sec:changes}
 
@@ -4047,6 +4018,7 @@ issues that are still to be resolved.
             \item Added \verb:UPPER(): function
             \item Added recommendation to data providers about case folding
             \item Re-added \verb:CAST(): function
+            \item Replaced the section for outstanding issues by the GitHub Issue mechanism
         \end{itemize}
 
     \item Changes from PR-ADQL-2.1-20180112

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -221,7 +221,7 @@ is case-insensitive.
 \texttt{BETWEEN,} \texttt{BIT,} \texttt{BIT\_LENGTH,} \texttt{BOTH,} 
 \texttt{BY,} \texttt{CASCADE,} \texttt{CASCADED,} \texttt{CASE,} 
 \texttt{CATALOG,} \texttt{CHAR,} \texttt{CHARACTER,}
-\texttt{CHARACTER\_LENGTH,} \texttt{CHAR\_LENGTH,} \texttt{CHECK,} 
+\texttt{CHAR\_LENGTH,} \texttt{CHARACTER\_LENGTH,} \texttt{CHECK,} 
 \texttt{CLOSE,} \texttt{COALESCE,} \texttt{COLLATE,} 
 \texttt{COLLATION,} \texttt{COLUMN,} \texttt{COMMIT,} 
 \texttt{CONNECT,} \texttt{CONNECTION,} \texttt{CONSTRAINT,} 
@@ -2945,7 +2945,7 @@ SHOULD support the following ones:
         \textit{\footnotesize{X: supported ; X*: supported but possible implementation differences}}
     }
 \end{table}
-\newpage % to force the compatibility table to be closed to the "Input types" paragragh
+\newpage % to force the compatibility table to be close to the "Input types" paragragh
 
 \paragraph{Cast into a smaller datatype}
 

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -220,7 +220,7 @@ is case-insensitive.
 \texttt{AT,} \texttt{AUTHORIZATION,} \texttt{AVG,} \texttt{BEGIN,} 
 \texttt{BETWEEN,} \texttt{BIT,} \texttt{BIT\_LENGTH,} \texttt{BOTH,} 
 \texttt{BY,} \texttt{CASCADE,} \texttt{CASCADED,} \texttt{CASE,} 
-\texttt{CAST,} \texttt{CATALOG,} \texttt{CHAR,} \texttt{CHARACTER,} 
+\texttt{CATALOG,} \texttt{CHAR,} \texttt{CHARACTER,}
 \texttt{CHARACTER\_LENGTH,} \texttt{CHAR\_LENGTH,} \texttt{CHECK,} 
 \texttt{CLOSE,} \texttt{COALESCE,} \texttt{COLLATE,} 
 \texttt{COLLATION,} \texttt{COLUMN,} \texttt{COMMIT,} 
@@ -234,7 +234,7 @@ is case-insensitive.
 \texttt{DEFAULT,} \texttt{DEFERRABLE,} \texttt{DEFERRED,} 
 \texttt{DELETE,} \texttt{DESC,} \texttt{DESCRIBE,} 
 \texttt{DESCRIPTOR,} \texttt{DIAGNOSTICS,} \texttt{DISCONNECT,} 
-\texttt{DISTINCT,} \texttt{DOMAIN,} \texttt{DOUBLE,} \texttt{DROP,} 
+\texttt{DISTINCT,} \texttt{DOMAIN,} \texttt{DROP,} 
 \texttt{ELSE,} \texttt{END,} \texttt{END-EXEC,} \texttt{ESCAPE,} 
 \texttt{EXCEPT,} \texttt{EXCEPTION,} \texttt{EXEC,} \texttt{EXECUTE,} 
 \texttt{EXISTS,} \texttt{EXTERNAL,} \texttt{EXTRACT,} \texttt{FALSE,} 
@@ -242,14 +242,14 @@ is case-insensitive.
 \texttt{FOREIGN,} \texttt{FOUND,} \texttt{FROM,} \texttt{FULL,} 
 \texttt{GET,} \texttt{GLOBAL,} \texttt{GO,} \texttt{GOTO,} 
 \texttt{GRANT,} \texttt{GROUP,} \texttt{HAVING,} \texttt{HOUR,} 
-\texttt{IDENTITY,} \texttt{IMMEDIATE,} \texttt{IN,} 
+\texttt{IDENTITY,} \texttt{IMMEDIATE,} \texttt{IN,}
 \texttt{INDICATOR,} \texttt{INITIALLY,} \texttt{INNER,} 
 \texttt{INPUT,} \texttt{INSENSITIVE,} \texttt{INSERT,} \texttt{INT,} 
-\texttt{INTEGER,} \texttt{INTERSECT,} \texttt{INTERVAL,} 
+\texttt{INTERSECT,} \texttt{INTERVAL,} 
 \texttt{INTO,} \texttt{IS,} \texttt{ISOLATION,} \texttt{JOIN,} 
 \texttt{KEY,} \texttt{LANGUAGE,} \texttt{LAST,} \texttt{LEADING,} 
 \texttt{LEFT,} \texttt{LEVEL,} \texttt{LIKE,} \texttt{LOCAL,} 
-\texttt{LOWER,} \texttt{MATCH,} \texttt{MAX,} \texttt{MIN,} 
+\texttt{MATCH,} \texttt{MAX,} \texttt{MIN,} 
 \texttt{MINUTE,} \texttt{MODULE,} \texttt{MONTH,} \texttt{NAMES,} 
 \texttt{NATIONAL,} \texttt{NATURAL,} \texttt{NCHAR,} \texttt{NEXT,} 
 \texttt{NO,} \texttt{NOT,} \texttt{NULL,} \texttt{NULLIF,} 
@@ -257,24 +257,24 @@ is case-insensitive.
 \texttt{ONLY,} \texttt{OPEN,} \texttt{OPTION,} \texttt{OR,} 
 \texttt{ORDER,} \texttt{OUTER,} \texttt{OUTPUT,} \texttt{OVERLAPS,} 
 \texttt{PAD,} \texttt{PARTIAL,} \texttt{POSITION,} 
-\texttt{PRECISION,} \texttt{PREPARE,} \texttt{PRESERVE,} 
+\texttt{PREPARE,} \texttt{PRESERVE,} 
 \texttt{PRIMARY,} \texttt{PRIOR,} \texttt{PRIVILEGES,} 
-\texttt{PROCEDURE,} \texttt{PUBLIC,} \texttt{READ,} \texttt{REAL,} 
+\texttt{PROCEDURE,} \texttt{PUBLIC,} \texttt{READ,} 
 \texttt{REFERENCES,} \texttt{RELATIVE,} \texttt{RESTRICT,} 
 \texttt{REVOKE,} \texttt{RIGHT,} \texttt{ROLLBACK,} \texttt{ROWS,} 
 \texttt{SCHEMA,} \texttt{SCROLL,} \texttt{SECOND,} \texttt{SECTION,} 
 \texttt{SELECT,} \texttt{SESSION,} \texttt{SESSION\_USER,} 
-\texttt{SET,} \texttt{SIZE,} \texttt{SMALLINT,} \texttt{SOME,} 
+\texttt{SET,} \texttt{SIZE,} \texttt{SOME,} 
 \texttt{SPACE,} \texttt{SQL,} \texttt{SQLCODE,} \texttt{SQLERROR,} 
 \texttt{SQLSTATE,} \texttt{SUBSTRING,} \texttt{SUM,} 
 \texttt{SYSTEM\_USER,} \texttt{TABLE,} \texttt{TEMPORARY,} 
-\texttt{THEN,} \texttt{TIME,} \texttt{TIMESTAMP,} 
+\texttt{THEN,} \texttt{TIME,} 
 \texttt{TIMEZONE\_HOUR,} \texttt{TIMEZONE\_MINUTE,} \texttt{TO,} 
 \texttt{TRAILING,} \texttt{TRANSACTION,} \texttt{TRANSLATE,} 
 \texttt{TRANSLATION,} \texttt{TRIM,} \texttt{TRUE,} \texttt{UNION,} 
-\texttt{UNIQUE,} \texttt{UNKNOWN,} \texttt{UPDATE,} \texttt{UPPER,} 
+\texttt{UNIQUE,} \texttt{UNKNOWN,} \texttt{UPDATE,} 
 \texttt{USAGE,} \texttt{USER,} \texttt{USING,} \texttt{VALUE,} 
-\texttt{VALUES,} \texttt{VARCHAR,} \texttt{VARYING,} \texttt{VIEW,} 
+\texttt{VALUES,} \texttt{VARYING,} \texttt{VIEW,} 
 \texttt{WHEN,} \texttt{WHENEVER,} \texttt{WHERE,} \texttt{WITH,} 
 \texttt{WORK,} \texttt{WRITE,} \texttt{YEAR,} \texttt{ZONE} 
 
@@ -289,7 +289,7 @@ Mathematical functions and operators:\\
 \texttt{EXP,} \texttt{FLOOR,} \texttt{LOG,} \texttt{LOG10,} 
 \texttt{MOD,} \texttt{PI,} \texttt{POWER,} \texttt{RADIANS,} 
 \texttt{RAND,} \texttt{ROUND,} \texttt{SIN,} \texttt{SQRT,} 
-\texttt{TAN,} \texttt{TOP,} \texttt{TRUNCATE}
+\texttt{TAN,} \texttt{TRUNCATE}
 \newline
 
 \noindent
@@ -299,6 +299,27 @@ Geometric functions and operators:\\
 \texttt{CONTAINS,} \texttt{COORD1,} \texttt{COORD2,} 
 \texttt{COORDSYS,} \texttt{DISTANCE,} \texttt{INTERSECTS,} 
 \texttt{POINT,} \texttt{POLYGON,} \texttt{REGION}
+\newline
+
+\noindent
+\verb:CAST: function and datatypes:\\
+\noindent
+\texttt{BIGINT,} \texttt{CAST,} \texttt{CHAR,} \texttt{DOUBLE PRECISION,} 
+\texttt{INTEGER,} \texttt{REAL,} \texttt{SMALLINT,} \texttt{TIMESTAMP,}
+\texttt{VARCHAR} 
+\newline
+
+\noindent
+String functions and operators:\\
+\noindent
+\texttt{ILIKE,} \texttt{LOWER,} \texttt{UPPER} 
+\newline
+
+\noindent
+Conversion functions:\\
+\noindent
+\texttt{IN\_UNIT}
+
 
 \subsubsection{Identifiers}
 \label{sec:adql.identifiers}
@@ -398,7 +419,7 @@ essentially, any \verb:<token>: may be followed by a \verb:<separator>:.
 \subsection{Query syntax}
 \label{sec:syntax}
 
-A more detailed definition of the select statement is given by the \verb:<query_specification>:
+A more detailed definition of the \verb:SELECT: statement is given by the \verb:<query_specification>:
 construct defined in \AppendixRef{sec:grammar}.
 
 A simplified syntax for the \verb:SELECT: statement follows, showing the main constructs for
@@ -416,10 +437,10 @@ the query specification:
     FROM {
         {
               table_name [ [AS] identifier ]
-            | ( SELECT ....) [ [AS] identifier ]
-            | table_name [NATURAL]
+            | ( SELECT ...) [AS] identifier
+            | table_reference [NATURAL]
                   [ INNER | { LEFT | RIGHT | FULL [OUTER] } ]
-                  JOIN table_name
+                  JOIN table_reference
                   [ON search_condition | USING ( column_name,...) ]
         },
         ...
@@ -656,7 +677,7 @@ usage and description are detailed in the following tables:
         \textit{n} integer &
         double &
         Rounds \textit{x} to \textit{n} decimal places.
-        The integer \textit{n} is optinal and defaults to 0 if not specified. 
+        The integer \textit{n} is optional and defaults to 0 if not specified. 
         A negative value of \textit{n} will round to the left of the decimal point.
         \tabularnewline
 
@@ -667,7 +688,7 @@ usage and description are detailed in the following tables:
         \textit{n} integer &
         double &
         Truncates \textit{x} to \textit{n} decimal places.
-        The integer \textit{n} is optinal and defaults to 0 if not specified. 
+        The integer \textit{n} is optional and defaults to 0 if not specified. 
         \tabularnewline
 
         \hline
@@ -1609,7 +1630,7 @@ which forms of query to optimise.  The result can be the
 unnecessarily slow operation of the common sky crossmatch operation.
 
 The purpose of this section is to recommend a preferred form of ADQL
-to use for sky crossmatches.  Clients posing crossmatch-like
+to use for sky crossmatches.  Clients proposing crossmatch-like
 queries are advised to phrase them this way rather than semantically
 equivalent alternatives, and services are encouraged to ensure that
 this form of join is executed efficiently; this might involve 
@@ -2924,6 +2945,7 @@ SHOULD support the following ones:
         \textit{\footnotesize{X: supported ; X*: supported but possible implementation differences}}
     }
 \end{table}
+\newpage % to force the compatibility table to be closed to the "Input types" paragragh
 
 \paragraph{Cast into a smaller datatype}
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCNAME = ADQL
 DOCVERSION = 2.1
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2018-01-12
+DOCDATE = 2021-05-28
 
 # What is it you're writing: NOTE, WD, PR, or REC
 DOCTYPE = PR

--- a/ivoa-cite.tex
+++ b/ivoa-cite.tex
@@ -38,6 +38,3 @@
 \newcommand{\SectionRef}[1]{Section \ref{#1}\xspace}
 \newcommand{\SectionSee}[1]{(see Section \ref{#1})\xspace}
 \newcommand{\AppendixRef}[1]{Appendix \ref{#1}\xspace}
-
-
-


### PR DESCRIPTION
This PullRequest includes:

- few typo corrections
- update of the ADQL and SQL reserved keywords in the text _(not in the BNF though it should probably be....which will be done anyway when changing the grammar for PEG in the next version of ADQL)_
- remove the Appendix C about Outstanding Issues ; I think it is now better to rely on the GitHub Issues mechanism instead of keeping a static list of issues in an IVOA document
- update the PR version

When this PullRequest is merged, I plan to publish the new PR in the IVOA Documents. After that the RFC could start.