### PR TITLE
Clarify that geometry types and functions are spherical

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1188,7 +1188,7 @@ operations on the image data.
 \label{sec:types.geom}
 
 ADQL provides support for the \verb:POINT:, \verb:CIRCLE: and \verb:POLYGON:
-geometric types defined in the \DALISpec.
+spherical geometry types defined in the \DALISpec.
 
 ADQL also provides support for STC-S based geometric regions,
 as defined in the \STCSSpec, using the \verb:REGION: datatype.
@@ -1196,7 +1196,8 @@ as defined in the \STCSSpec, using the \verb:REGION: datatype.
 \subsubsection{POINT}
 \label{sec:types.geom.point}
 
-The \verb:POINT: datatype maps to the corresponding type defined in the
+The \verb:POINT: datatype maps to the corresponding type
+for spherical coordinates defined in the
 \DALISpec.
 
 \verb:POINT: values are serialized as arrays of floating point numbers
@@ -1246,7 +1247,8 @@ For example:
 \subsubsection{CIRCLE}
 \label{sec:types.geom.circle}
 
-The \verb:CIRCLE: datatype maps to the corresponding type defined in the
+The \verb:CIRCLE: datatype maps to the corresponding type
+for spherical coordinates defined in the
 \DALISpec.
 
 \verb:CIRCLE: values are serialized as arrays of floating point numbers
@@ -1296,7 +1298,8 @@ For example:
 \subsubsection{POLYGON}
 \label{sec:types.geom.polygon}
 
-The \verb:POLYGON: datatype maps to the corresponding type defined in the
+The \verb:POLYGON: datatype maps to the corresponding type
+for spherical coordinates defined in the
 \DALISpec.
 
 \verb:POLYGON: values are serialized as arrays of floating point numbers
@@ -1430,14 +1433,10 @@ functions to enhance the astronomical usage of the language:
 \subsubsection{Coordinate limits}
 \label{sec:functions.geom.limits}
 
-If the arguments for a geometric function represent spherical coordinates
-then the values SHOULD be limited to [0, 360] and [-90, 90],
-and the units MUST be in degrees (square degrees for area).
+The arguments for a geometric function represent spherical coordinates
+in units of degrees (square degrees for area).
+The values SHOULD be limited to [0, 360] and [-90, 90].
             
-If the arguments for a geometric function represent cartesian coordinates
-then there are no inherent limits to the range of values, but
-coordinate vectors MUST be normalized.
-
 Details of the mechanism for reporting the out of range arguments are
 implementation dependent.
 


### PR DESCRIPTION
There are relics in the text of the (STC-1?) possibility of
using Cartesian coordinates alongside spherical coordinates
for ADQL geometries and data types.  Adjust the text to
clarify that geometries in ADQL are always spherical.

This includes making this explicit in the references to DALI
which is itself agnostic about coordinate system
(e.g. DALI 1.1 sec 3.3.5 says "Geometry values are two-dimensional;
although they are usually longitude and latitude values in spherical
coordinates this is specified in the coordinate metadata and not
in the values").