### PR TITLE
Fix broken links in HTML

### DIFF
--- a/ADQL.bib
+++ b/ADQL.bib
@@ -1,9 +1,0 @@
-@misc{note:VOARCH,
-	year=2010,
-	month=nov,
-	addurl={http://www.ivoa.net/documents/Notes/IVOAArchitecture},
-	author={Christophe Arviset and Severin Gaudet and the {IVOA} Technical Coordination Group},
-	editor = {Christophe Arviset},
-	title = {{IVOA} Architecture},
-	version = {1.0},
-	howpublished = {{IVOA Note}}}

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -71,7 +71,7 @@ education and outreach. The
 is a global collaboration of separately funded
 projects to develop standards and infrastructure that enable VO applications.
 
-\clearpage
+\clearpage % section cut
 \section{Introduction}
 \label{sec:introduction}
 
@@ -105,12 +105,11 @@ has been achieved as far as it can be done in SQL. The exact meaning of keywords
 indicating requirement levels can be found in the References section.
 %Should this be 'Conformance-related definitions' not 'References' ?
 
-
-\clearpage
+\clearpage % to have the VOArch figure along its description and subsection title
 \subsection{Role within the VO architecture}
 \label{sec:role}
 
-\begin{figure}
+\begin{figure}[th]
 \centering
 \includegraphics[width=0.9\textwidth]{ADQL-archdiag.png}
 \caption{Architecture diagram for this document}
@@ -133,7 +132,8 @@ Service implementations are free to extend this functionality by providing
 additional functions, operators or datatypes beyond those defined in this
 specification, as long as the extended functionality does not conflict
 with anything defined in this specification.
-\clearpage
+
+\clearpage % section cut
 \section{Language structure}
 \label{sec:language}
 
@@ -156,7 +156,7 @@ for ADQL. The following conventions are used through this document:
     \item Case-insensitive unless otherwise stated.
 \end{itemize}
 
-\clearpage
+
 \subsection{Characters, keywords, identifiers and literals}
 \subsubsection{Characters}
 \label{sec:characters}
@@ -411,7 +411,7 @@ Numeric literals are expressed as an exact decimal value, e.g. \verb:12: or
 The rules on where whitespace is allowed and required are as in SQL-92;
 essentially, any \verb:<token>: may be followed by a \verb:<separator>:.
 
-\clearpage
+\clearpage % to keep the entire verbatim block for query syntax on the same page
 \subsection{Query syntax}
 \label{sec:syntax}
 
@@ -544,7 +544,6 @@ case-insensitive string comparison operator, defined in \SectionRef{sec:string.f
     \item \verb:ILIKE:
 \end{itemize}
 
-\clearpage
 \subsection{Mathematical and Trigonometrical Functions}
 \label{sec:math.functions}
 
@@ -554,8 +553,7 @@ usage and description are detailed in the following tables:
 
 \begin{table}[th]\footnotesize
     \begin{tabular}{|p{0.20\textwidth}|p{0.125\textwidth}|p{0.125\textwidth}|p{0.55\textwidth}|}
-        \hline
-
+        
         \hline
         \textbf{Name} &
         \textbf{Argument \newline datatype} &
@@ -686,7 +684,6 @@ usage and description are detailed in the following tables:
         Truncates \textit{x} to \textit{n} decimal places.
         The integer \textit{n} is optional and defaults to 0 if not specified. 
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{Mathematical functions}
@@ -695,8 +692,7 @@ usage and description are detailed in the following tables:
 
 \begin{table}[th]\footnotesize
     \begin{tabular}{|p{0.20\textwidth}|p{0.125\textwidth}|p{0.125\textwidth}|p{0.55\textwidth}|}
-        \hline
-
+        
         \hline
         \textbf{Name} &
         \textbf{Argument \newline datatype} &
@@ -754,14 +750,13 @@ usage and description are detailed in the following tables:
         double &
         Returns the tangent of the angle \textit{x} in radians, in the range of -1.0 through 1.0.
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{Trigonometrical functions}
     \label{table:trig.functions}
 \end{table}
 
-\clearpage
+\clearpage % section cut
 \section{Type system}
 \label{sec:types}
 
@@ -794,11 +789,10 @@ corresponding datatypes defined in the \VOTableSpec{}.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.30\textwidth}|p{0.26\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
-        \multicolumn{3}{|c|}{\textbf{VOTable}}
+        \multicolumn{3}{c|}{\textbf{VOTable}}
         \tabularnewline
         
         \hline
@@ -814,13 +808,6 @@ corresponding datatypes defined in the \VOTableSpec{}.
         - &
         -
         \tabularnewline
-
-%       \hline
-%       ?? &
-%       unsignedByte &
-%       - &
-%       -
-%       \tabularnewline
 
         \hline
         SMALLINT &
@@ -856,7 +843,6 @@ corresponding datatypes defined in the \VOTableSpec{}.
         - &
         -
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for numeric values}
@@ -880,8 +866,7 @@ operate on some \verb:INTERVAL: values.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -924,8 +909,7 @@ The \verb:TIMESTAMP: datatype maps to the corresponding type defined in the
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -989,8 +973,7 @@ content.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -1016,7 +999,6 @@ content.
         n* &
         -
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for character strings}
@@ -1039,8 +1021,7 @@ defined functions that operate on some \verb:CLOB: values.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -1059,7 +1040,6 @@ defined functions that operate on some \verb:CLOB: values.
         n, n*, * &
         adql:clob
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for CLOB}
@@ -1091,8 +1071,7 @@ type defined in the \VOTableSpec{}.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -1118,7 +1097,6 @@ type defined in the \VOTableSpec{}.
         n* &
         -
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for binary arrays}
@@ -1142,8 +1120,7 @@ in the \VOTableSpec{}.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -1162,7 +1139,6 @@ in the \VOTableSpec{}.
         n, n*, * &
         adql:blob
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for BLOB}
@@ -1202,8 +1178,7 @@ using the \verb:point: xtype defined in the \DALISpec{}.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -1222,7 +1197,6 @@ using the \verb:point: xtype defined in the \DALISpec{}.
         2 &
         point
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for POINT}
@@ -1253,8 +1227,7 @@ using the \verb:circle: xtype defined in the \DALISpec{}.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -1273,7 +1246,6 @@ using the \verb:circle: xtype defined in the \DALISpec{}.
         3 &
         circle
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for CIRCLE}
@@ -1304,8 +1276,7 @@ using the \verb:polygon: xtype defined in the \DALISpec{}.
 \begin{table}[th]\footnotesize
     \begin{tabular}
         {|p{0.26\textwidth}|p{0.30\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|}
-        \hline
-
+        
         \hline
         \multicolumn{1}{|c|}{\textbf{ADQL}} &
         \multicolumn{3}{|c|}{\textbf{VOTable}}
@@ -1324,7 +1295,6 @@ using the \verb:polygon: xtype defined in the \DALISpec{}.
         n, *, n* &
         polygon
         \tabularnewline
-
         \hline
     \end{tabular}
     \caption{ADQL type mapping for POLYGON}
@@ -1366,7 +1336,7 @@ informal practice is to produce strings conforming to section 6
 of TAP 1.0 \citep{2010ivoa.spec.0327D} with an xtype of
 \texttt{adql:region}.
 
-\clearpage
+clearpage % section cut
 \section{Optional components}
 \label{sec:optional}
 
@@ -1658,14 +1628,6 @@ for the sky positions in the two tables, \textit{t1}, and \textit{t2}.
 
 Alternative semantically equivalent forms however MAY still be
 used by clients, and MUST still be handled correctly by services.
-
-%\subsubsection{Function definitions}
-\clearpage
-\label{sec:functions.geom.definitions}
-
-The following sections provide a detailed description for each geometrical
-function. In each case, the functionality and usage is described rather
-than going into the BNF grammar details as above.
 
 \subsubsection{AREA}
 \label{sec:functions.geom.area}
@@ -2940,7 +2902,6 @@ SHOULD support the following ones:
         \textit{\footnotesize{X: supported ; X*: supported but possible implementation differences}}
     }
 \end{table}
-\newpage % to force the compatibility table to be close to the "Input types" paragragh
 
 \paragraph{Cast into a smaller datatype}
 
@@ -3136,7 +3097,7 @@ then the OFFSET clause is applied first, dropping the specified
 number of rows from the beginning of the result set before the
 TOP clause is applied to limit the number of rows returned.
 
-\newpage
+\clearpage % section cut
 \appendix
 \section{BNF grammar}
 \label{sec:grammar}
@@ -3958,7 +3919,7 @@ TOP clause is applied to limit the number of rows returned.
 
 \end{verbatim}
 
-\newpage
+\clearpage % section cut
 \section{Language feature support}
 \label{sec:features}
 
@@ -3987,7 +3948,7 @@ For example, the following XML fragment describes a service that supports the
 </languageFeatures>    
 \end{verbatim}
 
-\newpage
+\clearpage % section cut
 \section{Changes from previous versions}
 \label{sec:changes}
 
@@ -4164,6 +4125,7 @@ For example, the following XML fragment describes a service that supports the
 
 \end{itemize}
 
+\clearpage % section cut
 \bibliography{ivoatex/ivoabib,ivoatex/docrepo}
 
 \end{document}

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -14,10 +14,6 @@
 
 \usepackage{hyperref}
 
-% Preserve spaces after \newcommand{}
-% https://tex.stackexchange.com/a/17873
-\usepackage{xspace}
-
 % Macros for referring to IVOA standards and notes.
 \input{ivoa-cite.tex}
 
@@ -776,8 +772,8 @@ the underlying database's native language and type system.
 However, service metadata needs to give column types in order to allow the
 construction of queries that are both syntactically and semantically correct.
 Examples of such metadata includes the \verb:TAP_SCHEMA: tables defined
-in the \TAPSpec and the \verb:/tables:
-webservice response defined in the \VOSISpec.
+in the \TAPSpec{} and the \verb:/tables:
+webservice response defined in the \VOSISpec{}.
 
 Services SHOULD, if at all possible, try to express their column metadata in
 these terms even if the underlying database employs different types.
@@ -793,7 +789,7 @@ VOTables into ADQL-visible tables.
 
 The numeric datatypes, \verb:BIT:, \verb:SMALLINT:, \verb:INTEGER:,
 \verb:BIGINT:, \verb:REAL:  \linebreak and \verb:DOUBLE PRECISION: map to the
-corresponding datatypes defined in the \VOTableSpec.
+corresponding datatypes defined in the \VOTableSpec{}.
 
 \begin{table}[th]\footnotesize
     \begin{tabular}
@@ -874,7 +870,7 @@ map to a 16 bit integer, \verb:INTEGER: should map to a 32 bit integer, etc.
 \subsubsection{INTERVAL}
 \label{sec:types.numeric.interval}
 
-The \DALISpec defines \verb:INTERVAL: as a pair of integer or floating-point
+The \DALISpec{} defines \verb:INTERVAL: as a pair of integer or floating-point
 numeric values which are serialized as an array of numbers.
 
 None of the ADQL operators apply to \verb:INTERVAL: values.
@@ -917,13 +913,13 @@ defined.
 \label{sec:types.datetime}
 
 Where possible, date and time values SHOULD be implemented as described in the
-\DALISpec.
+\DALISpec{}.
 
 \subsubsection{TIMESTAMP}
 \label{sec:types.datetime.timestamp}
 
 The \verb:TIMESTAMP: datatype maps to the corresponding type defined in the
-\DALISpec.
+\DALISpec{}.
 
 \begin{table}[th]\footnotesize
     \begin{tabular}
@@ -984,7 +980,7 @@ chronological time.
 \label{sec:types.character.primitive}
 
 The \verb:CHAR: and \verb:VARCHAR: datatypes map to the \verb:char: or
-\verb:unicodeChar: type defined in the \VOTableSpec.
+\verb:unicodeChar: type defined in the \VOTableSpec{}.
 
 The choice of whether \verb:CHAR: and \verb:VARCHAR: map to \verb:char: or
 \verb:unicodeChar: is implementation dependent and may depend on the data
@@ -1090,7 +1086,7 @@ specific operations on the generated URL field.
 \label{sec:types.binary.primitive}
 
 The \verb:BINARY: and \verb:VARBINARY: datatypes map to the \verb:unsignedByte:
-type defined in the \VOTableSpec.
+type defined in the \VOTableSpec{}.
 
 \begin{table}[th]\footnotesize
     \begin{tabular}
@@ -1141,7 +1137,7 @@ However, specific database implementations MAY provide user
 defined functions that operate on some \verb:BLOB: values.
 
 \verb:BLOB: values are serialized as arrays of \verb:unsignedByte: defined
-in the \VOTableSpec.
+in the \VOTableSpec{}.
 
 \begin{table}[th]\footnotesize
     \begin{tabular}
@@ -1188,20 +1184,20 @@ operations on the image data.
 \label{sec:types.geom}
 
 ADQL provides support for the \verb:POINT:, \verb:CIRCLE: and \verb:POLYGON:
-spherical geometry types defined in the \DALISpec.
+spherical geometry types defined in the \DALISpec{}.
 
 ADQL also provides support for STC-S based geometric regions,
-as defined in the \STCSSpec, using the \verb:REGION: datatype.
+as defined in the \STCSSpec{}, using the \verb:REGION: datatype.
 
 \subsubsection{POINT}
 \label{sec:types.geom.point}
 
 The \verb:POINT: datatype maps to the corresponding type
 for spherical coordinates defined in the
-\DALISpec.
+\DALISpec{}.
 
 \verb:POINT: values are serialized as arrays of floating point numbers
-using the \verb:point: xtype defined in the \DALISpec.
+using the \verb:point: xtype defined in the \DALISpec{}.
 
 \begin{table}[th]\footnotesize
     \begin{tabular}
@@ -1249,10 +1245,10 @@ For example:
 
 The \verb:CIRCLE: datatype maps to the corresponding type
 for spherical coordinates defined in the
-\DALISpec.
+\DALISpec{}.
 
 \verb:CIRCLE: values are serialized as arrays of floating point numbers
-using the \verb:circle: xtype defined in the \DALISpec.
+using the \verb:circle: xtype defined in the \DALISpec{}.
 
 \begin{table}[th]\footnotesize
     \begin{tabular}
@@ -1300,10 +1296,10 @@ For example:
 
 The \verb:POLYGON: datatype maps to the corresponding type
 for spherical coordinates defined in the
-\DALISpec.
+\DALISpec{}.
 
 \verb:POLYGON: values are serialized as arrays of floating point numbers
-using the \verb:polygon: xtype defined in the \DALISpec.
+using the \verb:polygon: xtype defined in the \DALISpec{}.
 
 \begin{table}[th]\footnotesize
     \begin{tabular}
@@ -1363,7 +1359,7 @@ these operations).
 We do not specify the serialisation of \verb:REGION:-typed values in result
 sets.  It is expected that next version of DALI will provide normative
 guidance on this. However, at least for the \textit{s\_region}
-column described in the \ObsCoreSpec,
+column described in the \ObsCoreSpec{},
 % ObsCore 1.1 Section 4.12
 % http://ivoa.net/documents/ObsCore/20170509/REC-ObsCore-v1.1-20170509.pdf#26
 informal practice is to produce strings conforming to section 6
@@ -1392,7 +1388,7 @@ ADQL queries that it sends.
 \subsection{Service capabilities}
 \label{sec:capabilities}
 
-The \TAPRegSpec defines an XML schema that a service SHOULD
+The \TAPRegSpec{} defines an XML schema that a service SHOULD
 use to declare which optional features it supports.
 
 In general, each group of language features is identified by a \verb:type:
@@ -1401,10 +1397,10 @@ feature name.
 
 \AppendixRef{sec:features} contains examples of how to declare support
 for each of the language features defined in this document using the
-XML schema from the \TAPRegSpec.
+XML schema from the \TAPRegSpec{}.
 
 For full details on the XML schema and how it can be used, please refer to
-the \TAPRegSpec.
+the \TAPRegSpec{}.
 
 \subsection{Geometrical functions}
 \label{sec:functions.geom}
@@ -1445,7 +1441,7 @@ implementation dependent.
 
 The following functions provide constructors for each of the geometry datatypes.
 The semantics of these datatypes are based on the corresponding
-concepts from the \STCSpec data model.
+concepts from the \STCSpec{} data model.
 
 The geometry datatypes and expressions are part of the core \verb:<value_expression>:
 in the ADQL grammar.
@@ -1503,7 +1499,7 @@ the appropriate conversion to make these operations possible. Now this argument
 is deprecated and will later be removed, the users should explicitly ask for
 such conversion. If this behavior is desired, the ADQL implementers have to
 allow it through User Defined Functions. Then, it is recommended to define them
-as declared in the \CatalogueUDF.
+as declared in the \CatalogueUDF{}.
 % Catalogue of {ADQL} User Defined Functions - Endorsed Note 1.0+
 % http://www.ivoa.net/documents/udf-catalogue/index.html
 
@@ -1719,7 +1715,7 @@ and will be removed from future versions of the specification.
 The BOX function expresses a box on the sky. A BOX is a special case of POLYGON,
 defined purely for convenience,
 and it corresponds semantically to the equivalent term, Box, defined in
-the \STCSpec.
+the \STCSpec{}.
 %(STC Box, Section 4.5.1.5)
 
 It is specified by a center position and size
@@ -1848,7 +1844,7 @@ contains geometric (POINT, BOX, CIRCLE, POLYGON or REGION) values.
 
 The CIRCLE function expresses a circular region on the sky (a cone in space),
 and it corresponds semantically to the equivalent term, Circle, defined in
-the \STCSpec.
+the \STCSpec{}.
 %(STC Circle, Section 4.5.1.2)
 
 The function arguments specify the center position and the radius, where:
@@ -2071,7 +2067,7 @@ been marked as deprecated. This function may be removed in future versions
 of this specification.
 Details of the coordinate system for a database column are available as part of
 the service metadata, available via the \verb:TAP_SCHEMA: tables defined in the
-\TAPSpec and the \verb:/tables: webservice response defined in the \VOSISpec.
+\TAPSpec{} and the \verb:/tables: webservice response defined in the \VOSISpec{}.
 
 %As described in \SectionRef{sec:functions.geom.overview}, the allowed return values must be defined
 %by any service making use of ADQL, and a list of standard coordinate system
@@ -2288,7 +2284,7 @@ implementation dependent.
 
 The POINT function expresses a single location on the sky,
 and it corresponds semantically to the equivalent term, SpatialCoord, defined in
-the \STCSpec.
+the \STCSpec{}.
 %(STC SpatialCoord, Section 4.4.2.2)
 
 The function arguments specify the position, where:
@@ -2478,7 +2474,7 @@ Observatory (GAVO):
 \end{verbatim}
 
 The \verb:ivo: prefix is reserved for functions that have been defined
-in an IVOA specification. For example the \RegTAPSpec defines the following
+in an IVOA specification. For example the \RegTAPSpec{} defines the following
 functions:
 \begin{verbatim}
     ivo_nocasematch()
@@ -2489,7 +2485,7 @@ functions:
 
 In order to avoid different signatures for the same functions, it is recommended
 that ADQL implementers follow as much as possible the User Defined Function
-signatures listed in the \CatalogueUDF.
+signatures listed in the \CatalogueUDF{}.
 % Catalogue of {ADQL} User Defined Functions - Endorsed Note 1.0+
 % http://www.ivoa.net/documents/udf-catalogue/index.html
 
@@ -2501,7 +2497,7 @@ signatures listed in the \CatalogueUDF.
 \label{sec:user.metadata}
 
 The URI for identifying the language feature for a user defined function
-is defined as part of the \TAPRegSpec.
+is defined as part of the \TAPRegSpec{}.
 
 \begin{verbatim}
     ivo://ivoa.net/std/TAPRegExt#features-udf
@@ -2532,7 +2528,7 @@ depending on the regular expression pattern matching:
     </languageFeatures>
 \end{verbatim}
 
-See the \TAPRegSpec for full details on how to use the
+See the \TAPRegSpec{} for full details on how to use the
 XML schema to declare user defined functions.
 
 \subsection{String functions and operators}
@@ -2972,7 +2968,7 @@ The rounding mechanism used when converting from approximate numerics
 \paragraph{Timestamp}
 
 Only a character string can be casted into a timestamp. This string MUST follow
-the syntax defined in the \DALISpec:
+the syntax defined in the \DALISpec{}:
 \begin{verbatim}
     YYYY-MM-DD[’T’hh:mm:ss[.SSS][’Z’]]
 \end{verbatim}
@@ -3032,9 +3028,9 @@ transformed into the unit defined by the second argument.
 The first argument MUST be a numeric expression.
 
 The second argument MUST be a string literal containing a valid unit
-description using the formatting defined in the \VOUnitSpec.
+description using the formatting defined in the \VOUnitSpec{}.
 
-It has to be noted that a unitless value, as defined by the \VOUnitSpec, can not
+It has to be noted that a unitless value, as defined by the \VOUnitSpec{}, can not
 be converted. Similarly a non-unitless value can not be converted into a
 unitless one.
 
@@ -3966,7 +3962,7 @@ TOP clause is applied to limit the number of rows returned.
 \section{Language feature support}
 \label{sec:features}
 
-In the \TAPRegSpec XML schema, each group of features is
+In the \TAPRegSpec{} XML schema, each group of features is
 described by a \verb:languageFeatures: element, which has a \verb:type:
 URI that identifies the group, and contains a \verb:form: element for each
 individual feature from the group that the service supports.
@@ -4144,7 +4140,7 @@ For example, the following XML fragment describes a service that supports the
             (svn version 3374)
         \end{itemize}
 
-    \item Changes from \TAPImpNote
+    \item Changes from \TAPImpNote{}
         \begin{itemize}
             \item 2.1.1.  The Separator Nonterminal
             \item 2.1.2.  Type System

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -118,7 +118,7 @@ indicating requirement levels can be found in the References section.
 \end{figure}
 
 Figure \ref{fig:archdiag} shows the role this document plays within the
-IVOA architecture \citep{note:VOARCH}.
+IVOA architecture \VOArch{}.
 
 \subsection{Extended functionality}
 \label{sec:extending}
@@ -4164,7 +4164,7 @@ For example, the following XML fragment describes a service that supports the
 
 \end{itemize}
 
-\bibliography{ivoatex/ivoabib,ivoatex/docrepo,ADQL}
+\bibliography{ivoatex/ivoabib,ivoatex/docrepo}
 
 \end{document}
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCTYPE = PR
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex
-SOURCES = $(DOCNAME).tex
+SOURCES = $(DOCNAME).tex ivoa-cite.tex
 
 # List of pixel image files to be included in submitted package 
 FIGURES = ADQL-archdiag.png

--- a/ivoa-cite.tex
+++ b/ivoa-cite.tex
@@ -12,29 +12,32 @@
 %   VOTable specification
 %
 
-\usepackage{etoolbox}
-\newcommand{\IvoaCite}[3]{\providebool{#1}\ifbool{#1}{#3}{#3\xspace(\citet{#2})\booltrue{#1}}\xspace}
+\def\definestandard#1#2#3{%
+  \expandafter\def\csname#1\endcsname{%
+    \expandafter\ifx\csname#1cited\endcsname\relax #3 \citep{#2}%
+    \expandafter\def\csname#1cited\endcsname{#1}%
+      \else #3\fi}}
 
-\newcommand{\VOTableSpec} {\IvoaCite{votspec}     {2013ivoa.spec.0920O} {VOTable specification}}
-\newcommand{\DALISpec}    {\IvoaCite{dalispec}    {2017ivoa.spec.0517D} {DALI specification}}
-\newcommand{\VOSISpec}    {\IvoaCite{vosispec}    {2017ivoa.spec.0524G} {VOSI specification}}
-\newcommand{\VOUnitSpec}  {\IvoaCite{unitspec}    {2014ivoa.spec.0523D} {VOUnits specification}}
+\definestandard{VOTableSpec}  {2013ivoa.spec.0920O} {VOTable specification}
+\definestandard{DALISpec}     {2017ivoa.spec.0517D} {DALI specification}
+\definestandard{VOSISpec}     {2017ivoa.spec.0524G} {VOSI specification}
+\definestandard{VOUnitSpec}   {2014ivoa.spec.0523D} {VOUnits specification}
 
-\newcommand{\RegTAPSpec}  {\IvoaCite{regtapspec}  {2014ivoa.spec.1208D} {RegTAP specification}}
+\definestandard{RegTAPSpec}   {2014ivoa.spec.1208D} {RegTAP specification}
 
-\newcommand{\TAPSpec}     {\IvoaCite{tapspec}     {2010ivoa.spec.0327D} {TAP specification}}
-\newcommand{\TAPRegSpec}  {\IvoaCite{tapregspec}  {2012ivoa.spec.0827D} {TAPRegExt specification}}
-\newcommand{\TAPImpNote}  {\IvoaCite{tapimpnote}  {note:TAPNotes}       {TAP implementation note}}
+\definestandard{TAPSpec}      {2010ivoa.spec.0327D} {TAP specification}
+\definestandard{TAPRegSpec}   {2012ivoa.spec.0827D} {TAPRegExt specification}
+\definestandard{TAPImpNote}   {2013ivoa.rept.1213D} {TAP Implementation Notes}
 
-\newcommand{\STCSpec}     {\IvoaCite{stcspec}     {2007ivoa.spec.1030R} {STC specification}}
-\newcommand{\STCSSpec}    {\IvoaCite{stcsspec}    {std:STCS}            {STC-S specification}}
-\newcommand{\ObsCoreSpec} {\IvoaCite{obscorespec} {2017ivoa.spec.0509L} {ObsCore specification}}
+\definestandard{STCSpec}      {2007ivoa.spec.1030R} {STC specification}
+\definestandard{STCSSpec}     {std:STCS}            {STC-S specification}
+\definestandard{ObsCoreSpec}  {2017ivoa.spec.0509L} {ObsCore specification}
 
-\newcommand{\CatalogueUDF} {\IvoaCite{udfcat}     {2021ivoa.spec.0310C} {Catalogue of ADQL User Defined Functions}}
+\definestandard{CatalogueUDF} {2021ivoa.spec.0310C} {Catalogue of ADQL User Defined Functions}
 
 %
 % Useful macros for referring to figures, sections and appendices in a consistent style.
-\newcommand{\FigureRef}[1]{Figure \ref{#1}\xspace}
-\newcommand{\SectionRef}[1]{Section \ref{#1}\xspace}
-\newcommand{\SectionSee}[1]{(see Section \ref{#1})\xspace}
-\newcommand{\AppendixRef}[1]{Appendix \ref{#1}\xspace}
+\newcommand{\FigureRef}[1]{Figure \ref{#1}}
+\newcommand{\SectionRef}[1]{Section \ref{#1}}
+\newcommand{\SectionSee}[1]{(see Section \ref{#1})}
+\newcommand{\AppendixRef}[1]{Appendix \ref{#1}}

--- a/ivoa-cite.tex
+++ b/ivoa-cite.tex
@@ -18,6 +18,8 @@
     \expandafter\def\csname#1cited\endcsname{#1}%
       \else #3\fi}}
 
+\definestandard{VOArch}       {2010ivoa.rept.1123A} {IVOA Architecture}
+
 \definestandard{VOTableSpec}  {2013ivoa.spec.0920O} {VOTable specification}
 \definestandard{DALISpec}     {2017ivoa.spec.0517D} {DALI specification}
 \definestandard{VOSISpec}     {2017ivoa.spec.0524G} {VOSI specification}


### PR DESCRIPTION
Update LaTeX macros referencing IVOA docs and remove xspace package dependency

`xspace` was used in these LaTeX macros. Due to it, links to IVOA documents were
sometimes broken in the HTML output.

This commit is a cherry-pick from db4a0fc08fa4892ba9e6e5c644451b088a358a8d

The issue was already discussed by email in January 2018:
<http://mail.ivoa.net/pipermail/dal/2018-January/007942.html>.

Fixes #60