### PR TITLE
Clarify discussion of coordsys argument

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1464,17 +1464,20 @@ and column references.
 \subsubsection{Coordsys}
 \label{sec:geom.coordsys.param}
 
-%TODO check on the list ...
-For historical reasons, the geometry constructors (BOX, CIRCLE, POINT
-and POLYGON) all accept an optional string literal as the first argument.
-This was originally intended to carry
-information on a reference system or other coordinate system metadata.
-As of this version of the specification this parameter has been
-marked as deprecated. Services are permitted to ignore this parameter and
-clients are advised to pass an empty string here. Future versions of this
-specification may remove this parameter from the listed functions.
+For historical reasons, the geometry constructors (\verb:BOX:, \verb:CIRCLE:,
+\verb:POINT: and \verb:POLYGON:) all accept a string literal as the first
+argument, hereafter called the COOSYS argument. Since version 2.1 of the
+specification, this parameter has been made optional and marked as deprecated.
+Future versions of this specification may remove this parameter from the listed
+functions.
 
-This coordinate system argument was originally intended to carry information on
+This specification makes no guarantees for any semantics for the deprecated
+COOSYS argument. Queries against services implementing ADQL 2.1 (or higher)
+SHOULD omit it. For interoperability, queries against 2.0 services SHOULD NOT
+pass arguments with differing COOSYS arguments to \verb:CONTAINS: or
+\verb:INTERSECTS:, as behaviour is undefined in that case.
+
+The COOSYS argument was originally intended to carry information on
 a reference system or other coordinate system metadata. This was helpful in
 order to deal with data specified in different coordinate systems while
 performing geometric operations. It was up to the ADQL service to perform

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -119,15 +119,15 @@ IVOA architecture \VOArch{}.
 \label{sec:extending}
 
 % Requested by Alberto Micol at ESO.
-% Explicit permisson for services that provide additional functionality.
-This document defines the minimum set of functions, operators and datatypes
+% Explicit permission for services that provide additional functionality.
+This document defines the minimum set of functions, operators and data types
 that a service MUST implement in order to register as a service that
-implements this version of the ADQL specification. It also defines optional
-features that a service MUST implement as such if it requires some or all of
-them.
+implements this version of the ADQL specification. Optional features defined in
+this specification MAY be implemented. However, if a service does provide one of
+them, it MUST be implemented according to this specification.
 
 Of course, service implementations are free to extend this functionality by
-providing additional functions, operators or datatypes beyond those defined in
+providing additional functions, operators or data types beyond those defined in
 this specification, as long as the extended functionality does not conflict
 with anything defined in this specification.
 

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1471,7 +1471,7 @@ specification, this parameter has been made optional and marked as deprecated.
 Future versions of this specification may remove this parameter from the listed
 functions.
 
-This specification makes no guarantees for any semantics for the deprecated
+This specification makes no guarantees about any semantics for the deprecated
 COOSYS argument. Queries against services implementing ADQL 2.1 (or higher)
 SHOULD omit it. For interoperability, queries against 2.0 services SHOULD NOT
 pass arguments with differing COOSYS arguments to \verb:CONTAINS: or

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -99,7 +99,7 @@ has been achieved as far as it can be done in SQL.
 This specification provides a complete definition of the ADQL through a single
 Backus Naur Form (BNF) based language definition. It includes both mandatory
 and optional features. Thus, this BNF aims to help implementing ADQL core
-features as well as some or all of the defined optional ones.
+features as well as the defined optional ones.
 
 \clearpage % to have the VOArch figure along its description and subsection title
 \subsection{Role within the VO architecture}


### PR DESCRIPTION
This PullRequest aims to clarify the explanations about how to (not) use the deprecated and optional COOSYS argument in geometry constructors (POINT, CIRCLE, ...).

This PR also:

- update the `ivoatex` submodule
- fix language and explanations as suggested by @Zarquan in the PR #66 discussions (see https://github.com/ivoa-std/ADQL/pull/66#discussion_r704502727 and https://github.com/ivoa-std/ADQL/pull/66#discussion_r704548396)

Fixes #58 