### PR TITLE
Add support for COALESCE

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -2832,6 +2832,7 @@ type conversion functions:
 
 \begin{itemize}
     \item \verb:CAST():
+    \item \verb:COALESCE():
 \end{itemize}
 
 \subsubsection{CAST}
@@ -2982,6 +2983,23 @@ Examples:
 
 Note that other serializations (e.g. STC/s) or any other kind of value MAY also
 be supported.
+
+\subsubsection{COALESCE}
+{\footnotesize Language feature :}\\
+{\footnotesize \verb|type: ivo://ivoa.net/std/TAPRegExt#features-adql-type|}\\
+{\footnotesize \verb|name: COALESCE|}\\
+
+The COALESCE function returns the first of its arguments that is not
+NULL. NULL is returned only if all arguments are NULL. 
+
+This is typcially used to provide fallback values:
+
+\begin{verbatim}
+COALESCE(access_url, '')
+\end{verbatim}
+
+will return an empty string when \verb|access_url| is NULL.
+
 
 \subsection{Unit operations}
 \label{sec:unit}
@@ -3367,6 +3385,11 @@ TOP clause is applied to limit the number of rows returned.
         | <coord_value>
 
     <circumflex> ::= ^
+
+    <coalesce_expression> ::= 
+        COALESCE <left_paren>
+            <value_expression>
+            [ { <comma> <value_expression }... ]
 
     <colon> ::= ":"
 
@@ -3921,6 +3944,7 @@ TOP clause is applied to limit the number of rows returned.
         | <column_reference>
         | <set_function_specification>
         | <cast_specification>
+        | <coalesce_expression>
         | <left_paren> <value_expression> <right_paren>
 
     <vertical_bar> ::= "|"

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -2832,7 +2832,6 @@ type conversion functions:
 
 \begin{itemize}
     \item \verb:CAST():
-    \item \verb:COALESCE():
 \end{itemize}
 
 \subsubsection{CAST}
@@ -2984,21 +2983,35 @@ Examples:
 Note that other serializations (e.g. STC/s) or any other kind of value MAY also
 be supported.
 
+\subsection{Conditional Functions}
+\label{sec:condfunc}
+
+An ADQL service implementation MAY include support for the following optional
+conditional functions: 
+
+\begin{itemize}
+    \item \verb:COALESCE():
+\end{itemize}
+
 \subsubsection{COALESCE}
 {\footnotesize Language feature :}\\
-{\footnotesize \verb|type: ivo://ivoa.net/std/TAPRegExt#features-adql-type|}\\
+{\footnotesize \verb|type: ivo://ivoa.net/std/TAPRegExt#features-adql-conditional|}\\
 {\footnotesize \verb|name: COALESCE|}\\
 
 The COALESCE function returns the first of its arguments that is not
 NULL. NULL is returned only if all arguments are NULL. 
 
-This is typcially used to provide fallback values:
+All arguments must be of the same datatype. An error should be returned
+if this rule is not respected. The way to report this error is
+implementation dependent.
+
+This is typically used to provide fallback values.  For instance,
 
 \begin{verbatim}
 COALESCE(access_url, '')
 \end{verbatim}
 
-will return an empty string when \verb|access_url| is NULL.
+\noindent will return an empty string when \verb|access_url| is NULL.
 
 
 \subsection{Unit operations}
@@ -3389,7 +3402,7 @@ TOP clause is applied to limit the number of rows returned.
     <coalesce_expression> ::= 
         COALESCE <left_paren>
             <value_expression>
-            [ { <comma> <value_expression }... ]
+            [ { <comma> <value_expression }... ] <right_paren>
 
     <colon> ::= ":"
 


### PR DESCRIPTION
This PR proposes to add the COALESCE function as an optional element
for ADQL.  This is fairly important in data-discovering RegTAP queries
as employed by https://github.com/msdemlei/pyvo/tree/add-discoverdata,
and working around its lack leads to rather nasty queries.

I'll hence propose to require it for RegTAP 1.2.  It'd hence be great if
it could yet sail into ADQL 2.1, in particular because RFC still hasn't
started and it's a minor addition.  But it's not the end of the world if
this gets pushed back to 2.2.