### PR TITLE
Accept NULL value wherever a value is expected

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1431,7 +1431,8 @@ in the ADQL grammar.
 
 \begin{verbatim}
     <value_expression> ::=
-        <numeric_value_expression>
+        NULL
+      | <numeric_value_expression>
       | <string_value_expression>
       | <geometry_value_expression>
 \end{verbatim}
@@ -2600,7 +2601,7 @@ to elsewhere in the main query.
 Using a common table expression can make complex queries easier to understand
 by factoring subqueries out of the main SQL statement.
 
-For example, the following query with a nested subquery: 
+For example, the following query with a nested subquery:
 \begin{verbatim}
     SELECT
         ra,
@@ -2846,7 +2847,7 @@ into the datatype specified by the second argument.
 \paragraph{Syntax} \verb:<cast_specification>:
 \begin{verbatim}
 CAST <left_paren>
-         ( <value_expression> | NULL ) AS <cast_target>
+         <value_expression> AS <cast_target>
      <right_paren>
 \end{verbatim}
 
@@ -3221,7 +3222,7 @@ TOP clause is applied to limit the number of rows returned.
       | CASCADE | CASCADED | CASE
       | CATALOG
       | CHARACTER | CHAR_LENGTH
-      | CHARACTER_LENGTH | CHECK | CLOSE | COALESCE
+      | CHARACTER_LENGTH | CHECK | CLOSE
       | COLLATE | COLLATION
       | COLUMN | COMMIT
       | CONNECT
@@ -3351,10 +3352,7 @@ TOP clause is applied to limit the number of rows returned.
         | <coord_value>
     
     <cast_specification> ::=
-        CAST <left_paren>
-            ( <value_expression> | NULL )
-            AS <cast_target>
-        <right_paren>
+        CAST <left_paren> <value_expression> AS <cast_target> <right_paren>
     
     <cast_target> ::=
           <character_string_type>
@@ -3948,7 +3946,8 @@ TOP clause is applied to limit the number of rows returned.
     <user_defined_function_param> ::= <value_expression>
 
     <value_expression> ::=
-        <numeric_value_expression>
+        NULL
+      | <numeric_value_expression>
       | <string_value_expression>
       | <geometry_value_expression>
 


### PR DESCRIPTION
Problem raised on the ADQL validator project:
https://github.com/ivoa/lyonetia/pull/16#issuecomment-1406523355

NULL is not allowed anywhere else than in `IS [NOT] NULL` and `CAST(...)`. In all DBMS, NULL is valid value in almost all places where a value is expected. This is actually a miss in ADQL-2.0. This Pull-Request aims to fix this issue. An Erratum will be added to ADQL-2.0 document.