### PR TITLE
Fix removed `TOP` keyword

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -282,9 +282,9 @@ is case-insensitive.
 \texttt{TIMEZONE\_HOUR,} \texttt{TIMEZONE\_MINUTE,} \texttt{TO,}
 \texttt{TRAILING,} \texttt{TRANSACTION,} \texttt{TRANSLATE,}
 \texttt{TRANSLATION,} \texttt{TRIM,} \texttt{TRUE,} \texttt{UNION,}
-\texttt{UNIQUE,} \texttt{UNKNOWN,} \texttt{UPDATE,} \texttt{UPPER}
+\texttt{UNIQUE,} \texttt{UNKNOWN,} \texttt{UPDATE,} \texttt{UPPER,}
 \texttt{USAGE,} \texttt{USER,} \texttt{USING,} \texttt{VALUE,}
-\texttt{VALUES,} \texttt{VARCHAR} \texttt{VARYING,} \texttt{VIEW,}
+\texttt{VALUES,} \texttt{VARCHAR,} \texttt{VARYING,} \texttt{VIEW,}
 \texttt{WHEN,} \texttt{WHENEVER,} \texttt{WHERE,} \texttt{WITH,}
 \texttt{WORK,} \texttt{WRITE,} \texttt{YEAR,} \texttt{ZONE}
 
@@ -298,7 +298,7 @@ Mathematical functions and operators:\\
 \texttt{ATAN2,} \texttt{CEILING,} \texttt{COS,} \texttt{COT,}
 \texttt{DEGREES,} \texttt{EXP,} \texttt{FLOOR,} \texttt{LOG,}
 \texttt{LOG10,} \texttt{MOD,}  \texttt{PI,} \texttt{POWER,}
-\texttt{RADIANS,}\texttt{RAND,} \texttt{ROUND,} \texttt{SIN,}
+\texttt{RADIANS,} \texttt{RAND,} \texttt{ROUND,} \texttt{SIN,}
 \texttt{SQRT,} \texttt{TAN,} \texttt{TRUNCATE}
 \newline
 

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -332,7 +332,7 @@ Conversion functions:\\
 \noindent
 Cardinality:\\
 \noindent
-\texttt{OFFSET}
+\texttt{OFFSET,} \texttt{TOP}
 \newline
 
 


### PR DESCRIPTION
This Pull-Request put back the keyword `TOP` in the ADQL reserved words list. It was accidently removed in 07c0de1.

Missing commas and a space are also added through this Pull-Request.

Fixes #85 