### PR TITLE
Review coordinate limits

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1486,8 +1486,14 @@ and column references.
 The arguments for a geometric function represent spherical coordinates
 in units of degrees (square degrees for area).
 
-Coordinates SHOULD be expressed in ranges matching the coordinate system they
-are expressed in (e.g. [0, 360] and [-90, 90] for equatorial coordinates).
+ADQL implementors and users MUST follow coordinate ranges defined in DALI 1.1
+and later.
+
+Note that at the time of the ADQL 2.1 recommendation, no agreed-upon, reliable,
+IVOA-approved convention for what ranges apply to which reference system exists.
+Such convention is foreseen to be defined in DALI. Presently, DALI 1.1 only
+defines ranges for equatorial coordinates. However, this is expected to be
+updated in future DALI versions.
 
 Details of the mechanism for reporting the out of range arguments are
 implementation dependent.
@@ -1666,10 +1672,9 @@ where:
 \begin{itemize}
     \item the center position is given by a pair of numeric coordinates
           in degrees, or a single geometric POINT
-    \item the coordinates of the center position SHOULD be within the ranges
-          matching their coordinate system
-          (see \SectionRef{sec:functions.geom.limits})
-    \item the width and height are given by numeric values in degrees.
+    \item the values of coordinates of the center position are subject to the
+          constraints laid down in \SectionRef{sec:functions.geom.limits}
+    \item the width and height are given by numeric values in degrees
 \end{itemize}
 
 For example, a BOX of ten degrees centered on a position
@@ -1744,9 +1749,8 @@ The function arguments specify the center position and the radius, where:
 \begin{itemize}
     \item the center position is given by a pair of numeric coordinates
           in degrees, or a single geometric POINT
-    \item the coordinates of the center position SHOULD be within the ranges
-          matching their coordinate system
-          (see \SectionRef{sec:functions.geom.limits})
+    \item the values of coordinates of the center position are subject to the
+          constraints laid down in \SectionRef{sec:functions.geom.limits}
     \item the radius is a numeric value in degrees.
 \end{itemize}
 
@@ -2051,8 +2055,8 @@ the \STCSpec{}.
 The function arguments specify the position, where:
 \begin{itemize}
     \item the position is given by a pair of numeric coordinates in degrees
-    \item the coordinates SHOULD be within the ranges matching their coordinate
-          system (see \SectionRef{sec:functions.geom.limits}).
+    \item the values of coordinates are subject to the constraints laid down in
+          \SectionRef{sec:functions.geom.limits}
 \end{itemize}
 
 For example, a function expressing a point with right ascension of 25 degrees
@@ -2102,8 +2106,8 @@ The function arguments specify three or more vertices, where:
 \begin{itemize}
     \item the position of the vertices are given as a sequence of numeric
           coordinates in degrees, or as a sequence of geometric POINTs
-    \item the coordinates SHOULD be within the ranges matching their coordinate
-          system (see \SectionRef{sec:functions.geom.limits}).
+    \item the values of coordinates are subject to the constraints laid down in
+          \SectionRef{sec:functions.geom.limits}
 \end{itemize}
 
 For example, a function expressing a triangle with vertices at (10.0,

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1437,18 +1437,6 @@ language features would be created for ADQL. So, for historical and
 interoperability reasons the IVOID for the geometry features must not have this
 hyphen.
 
-\subsubsection{Coordinate limits}
-\label{sec:functions.geom.limits}
-
-The arguments for a geometric function represent spherical coordinates
-in units of degrees (square degrees for area).
-In an equatorial coordinate system, values SHOULD be limited to [0, 360] and
-[-90, 90]. In a galactic coordinate system, they SHOULD be limited to
-[-180, 180] and [-90, 90].
-
-Details of the mechanism for reporting the out of range arguments are
-implementation dependent.
-
 \subsubsection{Datatype functions}
 \label{sec:functions.geom.type}
 
@@ -1491,6 +1479,18 @@ where
 \end{verbatim}
 and \verb:<value_expression_primary>: enables the use of geometric functions
 and column references.
+
+\subsubsection{Coordinate limits}
+\label{sec:functions.geom.limits}
+
+The arguments for a geometric function represent spherical coordinates
+in units of degrees (square degrees for area).
+
+Coordinates SHOULD be expressed in ranges matching the coordinate system they
+are expressed in (e.g. [0, 360] and [-90, 90] for equatorial coordinates).
+
+Details of the mechanism for reporting the out of range arguments are
+implementation dependent.
 
 \subsubsection{Coordinate system}
 \label{sec:geom.coordsys.param}
@@ -1665,10 +1665,11 @@ The function arguments specify the center position and the width and height,
 where:
 \begin{itemize}
     \item the center position is given by a pair of numeric coordinates
-    in degrees, or a single geometric POINT
-    \item the width and height are given by numeric values in degrees
-    \item the center position and the width and height MUST be within the ranges defined in
-    \SectionRef{sec:functions.geom.limits}.
+          in degrees, or a single geometric POINT
+    \item the coordinates of the center position SHOULD be within the ranges
+          matching their coordinate system
+          (see \SectionRef{sec:functions.geom.limits})
+    \item the width and height are given by numeric values in degrees.
 \end{itemize}
 
 For example, a BOX of ten degrees centered on a position
@@ -1742,10 +1743,11 @@ the \STCSpec{}.
 The function arguments specify the center position and the radius, where:
 \begin{itemize}
     \item the center position is given by a pair of numeric coordinates
-    in degrees, or a single geometric POINT
-    \item the radius is a numeric value in degrees
-    \item the center position and the radius MUST be within the ranges defined in
-    \SectionRef{sec:functions.geom.limits}.
+          in degrees, or a single geometric POINT
+    \item the coordinates of the center position SHOULD be within the ranges
+          matching their coordinate system
+          (see \SectionRef{sec:functions.geom.limits})
+    \item the radius is a numeric value in degrees.
 \end{itemize}
 
 For example, a CIRCLE of ten degrees radius centered on position
@@ -2049,8 +2051,8 @@ the \STCSpec{}.
 The function arguments specify the position, where:
 \begin{itemize}
     \item the position is given by a pair of numeric coordinates in degrees
-    \item the numeric coordinates MUST be within the ranges defined in
-    \SectionRef{sec:functions.geom.limits}.
+    \item the coordinates SHOULD be within the ranges matching their coordinate
+          system (see \SectionRef{sec:functions.geom.limits}).
 \end{itemize}
 
 For example, a function expressing a point with right ascension of 25 degrees
@@ -2098,10 +2100,10 @@ implicitly connected to the first vertex.
 
 The function arguments specify three or more vertices, where:
 \begin{itemize}
-    \item the position of the vertices are given as a sequence of
-    numeric coordinates in degrees, or as a sequence of geometric POINTs
-    \item the numeric coordinates MUST be within the ranges defined in
-    \SectionRef{sec:functions.geom.limits}
+    \item the position of the vertices are given as a sequence of numeric
+          coordinates in degrees, or as a sequence of geometric POINTs
+    \item the coordinates SHOULD be within the ranges matching their coordinate
+          system (see \SectionRef{sec:functions.geom.limits}).
 \end{itemize}
 
 For example, a function expressing a triangle with vertices at (10.0,
@@ -2159,9 +2161,9 @@ Future versions of this specification may remove this parameter
 
 
 The REGION function provides a way of expressing a complex region
-represented by a single string literal.  The standard expressly only
+represented by a single string literal. The standard expressly only
 requires literals as arguments rather than string expressions or column
-references.  The latter would require parsing these representations
+references. The latter would require parsing these representations
 within the database, which is not intended.
 
 This document does not specify possible syntaxes for REGION literals. A de-facto
@@ -2961,7 +2963,7 @@ For example, the following XML fragment describes a service that supports the
                     \item Clarification about the serialization of geometries in
                           the \verb:SELECT: clause: basically, use the syntax
                           described in DALI \SectionSee{sec:types.geom}
-                    \item Clarification about coordinates limits
+                    \item Clarification about coordinate limits
                           \SectionSee{sec:functions.geom.limits}
                     \item Clarification about geometry types and functions being
                           spherical

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1442,7 +1442,9 @@ hyphen.
 
 The arguments for a geometric function represent spherical coordinates
 in units of degrees (square degrees for area).
-The values SHOULD be limited to [0, 360] and [-90, 90].
+In an equatorial coordinate system, values SHOULD be limited to [0, 360] and
+[-90, 90]. In a galactic coordinate system, they SHOULD be limited to
+[-180, 180] and [-90, 90].
 
 Details of the mechanism for reporting the out of range arguments are
 implementation dependent.


### PR DESCRIPTION
As raised in [RFC-2.1](https://wiki.ivoa.net/twiki/bin/view/IVOA/ADQL21RFC) (Grid and DAL WGs), coordinates limits given in this document are now obsolete since we deprecated the coordinate system argument in geometrical functions.

In ADQL-2.0 and the current state of ADQL-2.1, coordinates are limited to [0, 360] and [-90, 90]. But if any coordinate system is allowed, these ranges may not be valid anymore. Galactic coordinates are usually limited to [-180, 180] and [-90, 90].

What should we do?
1. Just remove this section about limits (but still keep the constraint about spherical coordinates being expressed in degree)?
2. Give an exhaustive list of ranges for each coordinate system? _(what I have just tried to do in this PR)_
3. Give a relaxed couple of coordinates limits (e.g. [-180, 360])?

I am not an expect in term of coordinate systems and coordinates limits, so, any advice here is very welcome :slightly_smiling_face: 