### PR TITLE
RFC corrections suggested by DAL WG

### DIFF
--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1536,9 +1536,9 @@ coordinates of its geometric operands if they are expressed in different
 coordinate systems. However, be aware that in a future version of ADQL, these
 functions will no longer be expected to perform any coordinate conversion.
 Consequently, it is recommanded to avoid relying on this deprecated feature.
-For interoperability reasons, queries against 2.0 services SHOULD NOT pass
-arguments with differing COOSYS arguments to \verb:DISTANCE:, \verb:CONTAINS:
-or \verb:INTERSECTS:, as behaviour is undefined in that case.
+For interoperability reasons, queries against 2.0 or later services SHOULD NOT
+pass arguments with differing COOSYS arguments to \verb:DISTANCE:,
+\verb:CONTAINS: or \verb:INTERSECTS:, as behaviour is undefined in that case.
 
 \subsubsection{Predicate functions}
 \label{sec:functions.geom.predicate}

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -2235,6 +2235,12 @@ following functions:
     ivo_string_agg()
 \end{verbatim}
 
+The \CatalogueUDF{} collects many \verb:ivo: prefixed functions defined in other
+IVOA specifications, Endorsed Notes and functions defined in at least two
+implementations. At the time of this writing it is the only endorsed IVOA
+document providing such a collection of \verb:ivo: prefixed functions. It is
+then strongly recommended to follow function names and definitions from this
+catalogue when providing functions offering identical or similar functionnality.
 
 \subsubsection{Metadata}
 \label{sec:user.metadata}

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -425,6 +425,22 @@ Numeric literals are expressed as an exact decimal value, e.g. \verb:12: or
 The rules on where whitespace is allowed and required are as in SQL-92;
 essentially, any \verb:<token>: may be followed by a \verb:<separator>:.
 
+\subsubsection{Comments}
+\label{sec:comments}
+
+As in SQL-92, comments are supported in ADQL. A comment can be anywhere in the
+query. It starts with a double minus sign and ends with the end of line.
+
+\begin{verbatim}
+    <comment> ::= <comment_introducer> [ <comment_character>... ] <newline>
+
+    <comment_character> ::= <nonquote_character> | <quote>
+
+    <comment_introducer> ::= <minus_sign><minus_sign> [<minus_sign>...]
+\end{verbatim}
+
+Comments are not expected to be interpreted by ADQL parsers.
+
 \clearpage % to keep the entire verbatim block for query syntax on the same page
 \subsection{Query syntax}
 \label{sec:syntax}
@@ -2894,6 +2910,8 @@ For example, the following XML fragment describes a service that supports the
                           \verb:BLOB: \SectionSee{sec:types}
                     \item Language feature description
                           (see \AppendixRef{sec:features})
+                    \item Syntax description for comments inside a query
+                          (see \SectionRef{sec:comments})
                 \end{itemize}
             \item \textbf{Updated}
                 \begin{itemize}

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -1466,12 +1466,13 @@ implementation dependent.
 \subsubsection{Datatype functions}
 \label{sec:functions.geom.type}
 
-The following functions provide constructors for each of the geometry datatypes.
-The semantics of these datatypes are based on the corresponding
-concepts from the \STCSpec{} data model.
+Some of the functions described in this section (e.g. \verb:POINT:,
+\verb:CIRCLE:) are constructors for each of the geometry datatypes. The
+semantics of these datatypes are based on the corresponding concepts from the
+\STCSpec{} data model.
 
-The geometry datatypes and expressions are part of the core \verb:<value_expression>:
-in the ADQL grammar.
+The geometry datatypes and expressions are part of the core
+\verb:<value_expression>: in the ADQL grammar.
 
 \begin{verbatim}
     <value_expression> ::=

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -383,11 +383,19 @@ moving between backend RDBMSes.
 \subsubsection{Literals}
 \label{sec:literals}
 
-String literals are expressed as a character expression delimited by single quotes.
+String literals are expressed as a character expression delimited by single
+quotes.
 
 \begin{verbatim}
     <character_string_literal> ::=
         <quote> [ <character_representation>... ] <quote>
+\end{verbatim}
+
+A single quote inside a string literal must be escaped with a second single
+quote. For instance:
+
+\begin{verbatim}
+    'Earth''s satellite is the Moon.'
 \end{verbatim}
 
 Numeric literals are expressed as an exact decimal value, e.g. \verb:12: or
@@ -2920,6 +2928,8 @@ For example, the following XML fragment describes a service that supports the
                           (see \AppendixRef{sec:features})
                     \item Syntax description for comments inside a query
                           (see \SectionRef{sec:comments})
+                    \item Description of how to escape single quotes in a string
+                          literal (see \SectionRef{sec:literals})
                 \end{itemize}
             \item \textbf{Updated}
                 \begin{itemize}

--- a/ADQL.tex
+++ b/ADQL.tex
@@ -428,8 +428,9 @@ essentially, any \verb:<token>: may be followed by a \verb:<separator>:.
 \subsubsection{Comments}
 \label{sec:comments}
 
-As in SQL-92, comments are supported in ADQL. A comment can be anywhere in the
-query. It starts with a double minus sign and ends with the end of line.
+As in SQL-92, comments are supported in ADQL. A comment is syntactically legal
+wherever whitespace is legal and can then stand in for that whitespace. It
+starts with a double minus sign and ends with the end of line.
 
 \begin{verbatim}
     <comment> ::= <comment_introducer> [ <comment_character>... ] <newline>


### PR DESCRIPTION
Here are some corrections suggested by the DAL WG:

- add section about comments in query
- add a paragraph explaining how to escape a single quote in a string literal
- reword intro of the section "Datatype functions" (about geometry constructors)
- fix ADQL versions not allowing differing COOSYS arguments in the section "Coordinate System"
- add explicit recommendation to use the EN for the Catalogue of UDF
